### PR TITLE
Romanlab patch 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/<language>:<version TAG>
+    steps:
+      - checkout
+      - run: <command>
+  test:
+    docker:
+      - image: circleci/<language>:<version TAG>
+    steps:
+      - checkout
+      - run: <command>
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/<language>:<version TAG>
+      - image: circleci/<language>:latest
     steps:
       - checkout
       - run: <command>


### PR DESCRIPTION
#### Original issue (Brief description of original problem)
- platform install inside Docker build could silently change due to out of date `yarn.lock` file
#### Changes proposed (Brief description of solution and how it addresses the problem)
- added `--check-files` to `yarn install` command run for config repo From platform image
- this should cause a yarn sync issue to trigger a failure to install
@i-Sight/product-team